### PR TITLE
Conversão para mensagens ROS/Gazebo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,10 @@ target_link_libraries(multi_receiver_test
 #############
 
 ## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_travesim_adapters.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
+catkin_add_gtest(${PROJECT_NAME}-test src/lib/data/test/robot_state.test.cpp)
+if(TARGET ${PROJECT_NAME}-test)
+  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME} ${catkin_LIBRARIES})
+endif()
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)

--- a/include/travesim_adapters/data/entity_state.hpp
+++ b/include/travesim_adapters/data/entity_state.hpp
@@ -11,6 +11,10 @@
 #ifndef __ENTITY_STATE_H__
 #define __ENTITY_STATE_H__
 
+#include <geometry_msgs/Vector3.h>
+#include <geometry_msgs/Point.h>
+#include <gazebo_msgs/ModelState.h>
+
 #include <iostream>
 
 namespace travesim {
@@ -27,6 +31,41 @@ class Vector2D {
          * @param y y quota
          */
         Vector2D(double x = 0, double y = 0);
+
+        /**
+         * @brief Construct a new Vector 2D object from Vector3 object
+         *
+         * @param vector3
+         */
+        Vector2D(geometry_msgs::Vector3* vector3);
+
+        /**
+         * @brief Construct a new Vector 2D object from Point object
+         *
+         * @param point
+         */
+        Vector2D(geometry_msgs::Point* point);
+
+        /**
+         * @brief Convert object to data type used in Gazebo
+         *
+         * @return geometry_msgs::Vector3
+         */
+        geometry_msgs::Vector3 to_Vector3();
+
+        /**
+         * @brief Convert object to data type used in Gazebo
+         *
+         * @return geometry_msgs::Vector3
+         */
+        geometry_msgs::Point to_Point();
+
+        /**
+         * @brief Perform a counter-clockwise rotation of the vector
+         *
+         * @param theta Rotation angle in radians
+         */
+        void rotate(double theta);
 
         /**
          * @brief Output stream operator overloading
@@ -63,6 +102,20 @@ class EntityState {
          * @param angular_velocity Angular velocity in rad/s
          */
         EntityState(Vector2D position, double angular_position, Vector2D velocity, double angular_velocity);
+
+        /**
+         * @brief Construct a new Entity State object from Model State object
+         *
+         * @param model_state
+         */
+        EntityState(gazebo_msgs::ModelState* model_state);
+
+        /**
+         * @brief Convert object to data type used in Gazebo
+         *
+         * @return gazebo_msgs::ModelState converted data
+         */
+        gazebo_msgs::ModelState to_ModelState();
 
         /**
          * @brief Output stream operator overloading

--- a/include/travesim_adapters/data/robot_state.hpp
+++ b/include/travesim_adapters/data/robot_state.hpp
@@ -12,6 +12,8 @@
 #define __ROBOT_STATE_H__
 
 #include <iostream>
+#include <gazebo_msgs/ModelState.h>
+
 #include "travesim_adapters/data/entity_state.hpp"
 
 namespace travesim {
@@ -40,6 +42,22 @@ class RobotState :
          */
         RobotState(Vector2D position, double angular_position, Vector2D velocity, double angular_velocity,
                    bool is_yellow, int id);
+
+        /**
+         * @brief Construct a new Robot State object from Model State object
+         *
+         * @param model_state
+         */
+        RobotState(gazebo_msgs::ModelState* model_state);
+
+        RobotState(gazebo_msgs::ModelState* model_state, bool is_yellow, int id);
+
+        /**
+         * @brief Convert object to data type used in Gazebo
+         *
+         * @return gazebo_msgs::ModelState converted data
+         */
+        gazebo_msgs::ModelState to_ModelState();
 
         /**
          * @brief Output stream operator overloading

--- a/package.xml
+++ b/package.xml
@@ -17,14 +17,20 @@
   <build_depend>boost</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>gazebo_msgs</build_depend>
 
   <build_export_depend>boost</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <build_export_depend>gazebo_msgs</build_export_depend>
 
   <exec_depend>boost</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>gazebo_msgs</exec_depend>
 
   <export>
   </export>

--- a/src/lib/data/entity_state.cpp
+++ b/src/lib/data/entity_state.cpp
@@ -8,9 +8,17 @@
  * @date 04/2021
  */
 
+#include <geometry_msgs/Point.h>
+#include <cmath>
 #include <iomanip>
 #include "travesim_adapters/data/entity_state.hpp"
 #include "travesim_adapters/data/data_constants.hpp"
+
+#define DEFAULT_Z_VALUE 0.022
+#define DEFAULT_ENTITY_NAME "vss_ball"
+#define DEFAULT_REFERENCE_FRAME "world"
+
+#define quaternion_to_theta(q0, q1, q2, q3) atan2(2*(q0*q1+q2*q3), 1 - 2*(q1*q1 + q2*q2))
 
 namespace travesim {
 /*****************************************
@@ -20,6 +28,43 @@ namespace travesim {
 Vector2D::Vector2D(double x, double y) {
     this->x = x;
     this->y = y;
+}
+
+Vector2D::Vector2D(geometry_msgs::Vector3* vector3) {
+    this->x = vector3->x;
+    this->y = vector3->y;
+}
+
+Vector2D::Vector2D(geometry_msgs::Point* point) {
+    this->x = point->x;
+    this->y = point->y;
+}
+
+void Vector2D::rotate(double theta) {
+    double old_x = this->x, old_y = this->y;
+
+    this->x = cos(theta)*old_x + sin(theta)*old_y;
+    this->y = -sin(theta)*old_x + cos(theta)*old_y;
+}
+
+geometry_msgs::Vector3 Vector2D::to_Vector3() {
+    geometry_msgs::Vector3 retval;
+
+    retval.x = this->x;
+    retval.y = this->y;
+    retval.z = 0;
+
+    return retval;
+}
+
+geometry_msgs::Point Vector2D::to_Point() {
+    geometry_msgs::Point retval;
+
+    retval.x = this->x;
+    retval.y = this->y;
+    retval.z = DEFAULT_Z_VALUE;
+
+    return retval;
 }
 
 std::ostream& operator <<(std::ostream& output, const Vector2D& vector_2d) {
@@ -43,6 +88,39 @@ EntityState::EntityState(Vector2D position, double angular_position, Vector2D ve
     this->angular_position = angular_position;
     this->velocity = velocity;
     this->angular_velocity = angular_velocity;
+}
+
+EntityState::EntityState(gazebo_msgs::ModelState* model_state) {
+    this->position = Vector2D(&model_state->pose.position);
+
+    this->angular_position = quaternion_to_theta(model_state->pose.orientation.w, model_state->pose.orientation.x,
+                                                 model_state->pose.orientation.y, model_state->pose.orientation.z);
+
+    this->velocity = Vector2D(&model_state->twist.linear);
+
+    this->angular_velocity = model_state->twist.angular.z;
+}
+
+gazebo_msgs::ModelState EntityState::to_ModelState() {
+    gazebo_msgs::ModelState retval;
+
+    retval.model_name = DEFAULT_ENTITY_NAME;
+    retval.reference_frame = DEFAULT_REFERENCE_FRAME;
+
+    retval.pose.position = this->position.to_Point();
+
+    retval.pose.orientation.w = cos(this->angular_position/2);
+    retval.pose.orientation.x = sin(this->angular_position/2);
+    retval.pose.orientation.y = 0;
+    retval.pose.orientation.z = 0;
+
+    retval.twist.linear = this->velocity.to_Vector3();
+
+    retval.twist.angular.x = 0;
+    retval.twist.angular.y = 0;
+    retval.twist.angular.z = this->angular_velocity;
+
+    return retval;
 }
 
 std::ostream& operator <<(std::ostream& output, const EntityState& entity_state) {

--- a/src/lib/data/robot_state.cpp
+++ b/src/lib/data/robot_state.cpp
@@ -27,6 +27,24 @@ RobotState::RobotState(Vector2D position, double angular_position, Vector2D velo
     this->id = id;
 }
 
+RobotState::RobotState(gazebo_msgs::ModelState* model_state) : RobotState(model_state, true, 0) {
+}
+
+RobotState::RobotState(gazebo_msgs::ModelState* model_state, bool is_yellow, int id) :
+    EntityState(model_state) {
+    this->is_yellow = is_yellow;
+    this->id = id;
+}
+
+gazebo_msgs::ModelState RobotState::to_ModelState() {
+    gazebo_msgs::ModelState retval = EntityState::to_ModelState();
+
+    std::string base_name = this->is_yellow ? "yellow_team/robot_" : "blue_team/robot_";
+    retval.model_name = base_name.append(std::to_string(this->id));
+
+    return retval;
+}
+
 std::ostream& operator <<(std::ostream& output, const RobotState& robot_state) {
     output << std::fixed << std::setprecision(PRINTING_DECIMAL_PRECISION);
 

--- a/src/lib/data/test/robot_state.test.cpp
+++ b/src/lib/data/test/robot_state.test.cpp
@@ -1,0 +1,71 @@
+// Bring in my package's API, which is what I'm testing
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <gtest/gtest.h>
+#include <gazebo_msgs/ModelState.h>
+#include <geometry_msgs/Vector3.h>
+
+#include "travesim_adapters/data/robot_state.hpp"
+
+// Declare a test
+TEST(robot_state_to_model_state, model_name)
+{
+    travesim::RobotState robot_state;
+
+    EXPECT_EQ(robot_state.to_ModelState().model_name, "yellow_team/robot_0");
+
+    robot_state.id = 2;
+
+    EXPECT_EQ(robot_state.to_ModelState().model_name, "yellow_team/robot_2");
+
+    robot_state.is_yellow = false;
+    robot_state.id = 0;
+
+    EXPECT_EQ(robot_state.to_ModelState().model_name, "blue_team/robot_0");
+
+    robot_state.id = 1;
+
+    EXPECT_EQ(robot_state.to_ModelState().model_name, "blue_team/robot_1");
+}
+
+TEST(robot_state_to_model_state, angle_conversion)
+{
+    travesim::RobotState robot_state;
+    robot_state.angular_position = -M_PI/3;
+
+    gazebo_msgs::ModelState model_state = robot_state.to_ModelState();
+
+    EXPECT_DOUBLE_EQ(travesim::RobotState(&model_state).angular_position, robot_state.angular_position);
+}
+
+TEST(vector2d_to_vector3, convert_from_vector2d)
+{
+    travesim::Vector2D vector2d(2, 4);
+
+    geometry_msgs::Vector3 vector3 = vector2d.to_Vector3();
+
+    EXPECT_DOUBLE_EQ(vector3.x, 2);
+    EXPECT_DOUBLE_EQ(vector3.y, 4);
+}
+
+TEST(vector2d_to_vector3, convert_from_vector3)
+{
+    geometry_msgs::Vector3 vector3;
+
+    vector3.x = 3;
+    vector3.y = -7;
+
+    travesim::Vector2D vector2d(&vector3);
+
+    EXPECT_DOUBLE_EQ(vector2d.x, 3);
+    EXPECT_DOUBLE_EQ(vector2d.y, -7);
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+
+    // ros::init(argc, argv, "tester");
+    // ros::NodeHandle nh;
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Salve salve galerinha

O @LucasHaug introduziu novas classes na PR #1 que descrevem as mensagens enviadas/recebidas por protobuf. Para auxiliar a nossa vida, adicionei uma série de métodos que convertem as classes protobuf para mensagens do contexto ROS/Gazebo

Curiosamente, essas conversões são um pouco mais complexas do que eu esperava ~fiquei particularmente surpreso~, pois o contexto protobuf trabalha com geometria 2d, ao passo que o Gazebo trabalha com geometria 3d. O maior BO sempre é converter quaternions para ângulos de Euler, mas a Wikipedia tem [formuletas prontas](https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles)

Por fim, adicionei alguns testes unitários pra conferência geral das conversões de valores. A action do Github ainda não executa os testes, mas essa adição foi feita na `feature/vision_adapter` então não adicionei aqui de novo pra não rolar conflito

No mais, fiquem bem e mantenham-se hidratados