### PR TITLE
Execução e relatório de testes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Build project with docker
+name: Build and test with docker
 on: push
 
 jobs:
@@ -6,12 +6,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Build the stack
         run: docker-compose build
-      - name: Export test results
+
+      - name: Export tests results
         run: docker-compose up && docker-compose down
-      - name: Publish Unit Test Results
+
+      - name: Publish unit tests report
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
+          check_name: tests report
           files: test_results/**/*.xml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,4 +7,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build the stack
-        run: docker build .
+        run: docker-compose build
+      - name: Export test results
+        run: docker-compose up && docker-compose down
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure() # run this step even if previous step failed
+        with:
+          name: JEST Tests # Name of the check run which will be created
+          path: test_results/**/*.xml # Path to test results
+          reporter: jest-junit # Format of test results

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,10 +10,8 @@ jobs:
         run: docker-compose build
       - name: Export test results
         run: docker-compose up && docker-compose down
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure() # run this step even if previous step failed
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
         with:
-          name: JEST Tests # Name of the check run which will be created
-          path: test_results/**/*.xml # Path to test results
-          reporter: jest-junit # Format of test results
+          files: test_results/**/*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# Hidden files
+~*
+
+# Test reports
+test_results/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,12 @@ RUN /ros_entrypoint.sh catkin_make install
 
 RUN /ros_entrypoint.sh catkin_make run_tests
 
-CMD cp -r ${CATKIN_WS}/build/test_results /var/ && /ros_entrypoint.sh catkin_test_results
+## By default, 'catkin_make run_tests' will only return non zero exit code
+# if the execution of tests returned an error. To throw an error upon test
+# failure, it is needed to run the following command. As we want to upload
+# the tests results (success and failure), we leave this line commented
+# and let the test report throw an error if needed
+
+# RUN /ros_entrypoint.sh catkin_test_results
+
+CMD cp -r ${CATKIN_WS}/build/test_results /var/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,9 @@ RUN . devel/setup.sh && apt update --fix-missing && rosdep install ${PROJECT_NAM
 
 # Compile project
 RUN /ros_entrypoint.sh catkin_make
+
+RUN /ros_entrypoint.sh catkin_make install
+
+RUN /ros_entrypoint.sh catkin_make run_tests
+
+CMD cp -r ${CATKIN_WS}/build/test_results /var/ && /ros_entrypoint.sh catkin_test_results

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  travesim_adapters:
+    container_name: travesim_adapters
+    build: .
+    volumes:
+      - ./test_results:/var/test_results


### PR DESCRIPTION
Salve salve garotada

Essa é uma atualização menor, que adiciona ao workflow de integração contínua um relatório de testes fofinho

![Captura de tela de 2021-04-14 14-52-46](https://user-images.githubusercontent.com/1054087/114757218-f5ef6f80-9d31-11eb-8150-8bcab6ab6ffb.png)

Enquanto eu trabalhava na branch `feature/ros_side`, percebi que o `rostest` estava gerando relatórios em .xml dos resultados dos testes (com formatação do JUnit) e procurei uma action do GitHub que fosse capaz de ler e mostrar o conteúdo dos relatórios. Peguei [essa daqui](https://github.com/EnricoMi/publish-unit-test-result-action), que foi a que funcionou melhor e ficou mais esteticamente agradável

A branch develop ainda não tem nenhum teste, então o relatório [aparece vazio](https://github.com/ThundeRatz/travesim_adapters/runs/2345697197?check_suite_focus=true), mas no universo paralelo que tem testes é possível ver o [relatório bonitinho](https://github.com/ThundeRatz/travesim_adapters/runs/2345222288?check_suite_focus=true)

No mais, essas são as alterações do momento. Fiquem bem e mantenham-se hidratados
