### PR TITLE
🎮 Receptor dos times

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(${PROJECT_NAME}_udp_comm
 
 add_library(${PROJECT_NAME}_protobuf_comm
   src/lib/protobuf/vision_sender.cpp
+  src/lib/protobuf/team_receiver.cpp
 )
 
 ## Declare a C++ executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,10 @@ add_executable(vision_receiver_example
   examples/protobuf/vision_receiver_example.cpp
 )
 
+add_executable(team_receiver_example
+  examples/protobuf/team_receiver_example.cpp
+)
+
 add_executable(vision_adapter
   src/bin/vision_adapter.cpp
 )
@@ -165,6 +169,12 @@ target_link_libraries(vision_sender_example
 )
 
 target_link_libraries(vision_receiver_example
+  ${PROJECT_NAME}_protobuf_comm
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(team_receiver_example
+  ${PROJECT_NAME}_core
   ${PROJECT_NAME}_protobuf_comm
   ${catkin_LIBRARIES}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,10 @@ add_library(${PROJECT_NAME}_core
   src/lib/data/entity_state.cpp
   src/lib/data/robot_state.cpp
   src/lib/data/field_state.cpp
-  src/lib/data/converter/ros_side.cpp
 )
 
 add_library(${PROJECT_NAME}_ros
+  src/lib/data/converter/ros_side.cpp
   src/lib/ros/vision_receiver.cpp
   src/lib/ros/teams_sender.cpp
 )
@@ -87,20 +87,20 @@ add_executable(multi_receiver_reset_example
   examples/udp/multicast_receiver_reset_example.cpp
 )
 
+add_executable(uni_receiver_example
+examples/udp/unicast_receiver_example.cpp
+)
+
+add_executable(uni_sender_example
+examples/udp/unicast_sender_example.cpp
+)
+
 add_executable(vision_sender_example
   examples/protobuf/vision_sender_example.cpp
 )
 
 add_executable(vision_receiver_example
   examples/protobuf/vision_receiver_example.cpp
-)
-
-add_executable(uni_receiver_example
-  examples/udp/unicast_receiver_example.cpp
-)
-
-add_executable(uni_sender_example
-  examples/udp/unicast_sender_example.cpp
 )
 
 add_executable(vision_adapter
@@ -147,6 +147,16 @@ target_link_libraries(multi_receiver_reset_example
   ${catkin_LIBRARIES}
 )
 
+target_link_libraries(uni_receiver_example
+  ${PROJECT_NAME}_udp_comm
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(uni_sender_example
+  ${PROJECT_NAME}_udp_comm
+  ${catkin_LIBRARIES}
+)
+
 target_link_libraries(vision_sender_example
   ${PROJECT_NAME}_core
   ${PROJECT_NAME}_protobuf_comm
@@ -155,16 +165,6 @@ target_link_libraries(vision_sender_example
 
 target_link_libraries(vision_receiver_example
   ${PROJECT_NAME}_protobuf_comm
-  ${catkin_LIBRARIES}
-)
-
-target_link_libraries(uni_receiver_example
-  ${PROJECT_NAME}_udp_comm
-  ${catkin_LIBRARIES}
-)
-
-target_link_libraries(uni_sender_example
-  ${PROJECT_NAME}_udp_comm
   ${catkin_LIBRARIES}
 )
 

--- a/examples/protobuf/team_receiver_example.cpp
+++ b/examples/protobuf/team_receiver_example.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file vision_receiver_example.cpp
+ *
+ * @author Lucas Haug <lucas.haug@thuneratz.org>
+ * @author Lucas Schneider <lucas.schneider@thuneratz.org>
+ * @author Felipe Gomes de Melo <felipe.gomes@thuneratz.org>
+ *
+ * @brief Example to read data published from vision adapter
+ *
+ * @date 04/2021
+ *
+ * @copyright MIT License - Copyright (c) 2021 ThundeRatz
+ */
+
+#include <iostream>
+#include <boost/asio.hpp>
+
+#include "travesim_adapters/protobuf/team_receiver.hpp"
+
+/*****************************************
+ * Private Constants
+ *****************************************/
+
+#define BUFFER_SIZE 1024U
+#define CLEAR_TERMINAL "\033[2J\033[H"
+
+/*****************************************
+ * Main Function
+ *****************************************/
+
+int main(int argc, char* argv[]) {
+    const std::string receiver_address = "127.0.0.1";
+    const short receiver_port = 20011;
+
+    travesim::TeamCommand team_yellow_cmd;
+
+    try {
+        boost::asio::io_context io_context;
+        boost::asio::steady_timer my_timer(io_context);
+        travesim::proto::TeamReceiver yellow_receiver(receiver_address, receiver_port, true);
+
+        size_t data_size = 0;
+
+        for (long int i = 0;; i++) {
+            bool received_new_msg = yellow_receiver.receive(&team_yellow_cmd);
+
+            if (received_new_msg) {
+                std::cout << team_yellow_cmd << CLEAR_TERMINAL;
+            }
+
+            my_timer.expires_after(std::chrono::milliseconds(1));
+            my_timer.wait();
+        }
+    } catch (std::exception& e) {
+        std::cerr << "Exception: " << e.what() << "\n";
+    }
+
+    return 0;
+}

--- a/examples/protobuf/team_receiver_example.cpp
+++ b/examples/protobuf/team_receiver_example.cpp
@@ -41,11 +41,11 @@ int main(int argc, char* argv[]) {
 
         size_t data_size = 0;
 
-        for (long int i = 0;; i++) {
+        while (true) {
             bool received_new_msg = yellow_receiver.receive(&team_yellow_cmd);
 
             if (received_new_msg) {
-                std::cout << team_yellow_cmd << CLEAR_TERMINAL;
+                std::cout << CLEAR_TERMINAL << team_yellow_cmd;
             }
 
             my_timer.expires_after(std::chrono::milliseconds(1));

--- a/include/travesim_adapters/protobuf/team_receiver.hpp
+++ b/include/travesim_adapters/protobuf/team_receiver.hpp
@@ -1,0 +1,92 @@
+/**
+ * @file team_receiver.hpp
+ *
+ * @author Lucas Haug <lucas.haug@thunderatz.org>
+ *
+ * @brief Team control data receiver with UDP and protobuf
+ *
+ * @date 04/2021
+ *
+ * @copyright MIT License - Copyright (c) 2021 ThundeRatz
+ */
+
+#include "travesim_adapters/udp/unicast_receiver.hpp"
+#include "travesim_adapters/data/team_command.hpp"
+#include "packet.pb.h"
+
+#ifndef __TEAM_RECEIVER_H__
+#define __TEAM_RECEIVER_H__
+
+namespace travesim {
+namespace proto {
+/**
+ * @brief Team control data receiver class with UDP and protobuf
+ */
+class TeamReceiver {
+    public:
+        /**
+         * @brief Construct a new TeamReceiver object
+         *
+         * @param receiver_address Team control address
+         * @param receiver_port Team control port
+         * @param is_yellow Wheter to tecontrol team yellow or blue
+         *
+         * @note The unicast addresses must be in the block 127.0.0.0/8, see
+         *       [IANA IPv4 Address Space Registry]
+         *       (https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml)
+         *       or the [RFC6890](https://tools.ietf.org/html/rfc6890) for more informations.
+         */
+        TeamReceiver(const std::string receiver_address, const short receiver_port, bool is_yellow);
+
+        /**
+         * @brief Destroy the TeamReceiver object
+         */
+        ~TeamReceiver();
+
+        /**
+         * @brief Receive the command from a team
+         *
+         * @param p_team_cmd Pointer where to store the team command
+         *
+         * @return true if a new message was received, false otherwise
+         */
+        bool receive(TeamCommand* p_team_cmd);
+
+        /**
+         * @brief Set the receiver endpoint
+         *
+         * @param receiver_address Team control address
+         * @param receiver_port Team control port
+         *
+         * @note The unicast addresses must be in the block 127.0.0.0/8, see
+         *       [IANA IPv4 Address Space Registry]
+         *       (https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml)
+         *       or the [RFC6890](https://tools.ietf.org/html/rfc6890) for more informations.
+         */
+        void set_receiver_endpoint(const std::string receiver_address, const short receiver_port);
+
+        /**
+         * @brief Reset the receiver
+         */
+        void reset(void);
+
+        /**
+         * @brief Convert a Packet protobuf message object to a TeamCommand object
+         *
+         * @param p_packet Pointer to the packet message to be converted
+         *
+         * @return TeamCommand
+         */
+        TeamCommand packet_pb_msg_to_team_command(fira_message::sim_to_ref::Packet* p_packet);
+
+    private:
+        udp::UnicastReceiver* unicast_receiver;  /**< UDP unicast receiver */
+
+        bool is_yellow;  /**< true for yellow, false for blue */
+
+        TeamCommand last_team_cmd;
+};
+}  // namespace proto
+}  // namespace travesim
+
+#endif // __TEAM_RECEIVER_H__

--- a/include/travesim_adapters/protobuf/team_receiver.hpp
+++ b/include/travesim_adapters/protobuf/team_receiver.hpp
@@ -71,13 +71,12 @@ class TeamReceiver {
         void reset(void);
 
         /**
-         * @brief Convert a Packet protobuf message object to a TeamCommand object
+         * @brief Update a TeamCommand object from a Packet protobuf message
          *
          * @param p_packet Pointer to the packet message to be converted
-         *
-         * @return TeamCommand
+         * @param p_team_cmd Pointer where to store the team command
          */
-        TeamCommand packet_pb_msg_to_team_command(fira_message::sim_to_ref::Packet* p_packet);
+        void packet_pb_msg_to_team_command(fira_message::sim_to_ref::Packet* p_packet, TeamCommand* p_team_cmd);
 
     private:
         udp::UnicastReceiver* unicast_receiver;  /**< UDP unicast receiver */

--- a/src/lib/protobuf/team_receiver.cpp
+++ b/src/lib/protobuf/team_receiver.cpp
@@ -46,7 +46,7 @@ bool TeamReceiver::receive(TeamCommand* p_team_cmd) {
         packet_data.ParseFromArray(buffer, BUFFER_SIZE);
 
         if (packet_data.has_cmd()) {
-            *p_team_cmd = this->packet_pb_msg_to_team_command(&packet_data);
+            this->packet_pb_msg_to_team_command(&packet_data, p_team_cmd);
 
             last_team_cmd = *p_team_cmd;
 
@@ -71,9 +71,7 @@ void TeamReceiver::reset(void) {
     this->unicast_receiver->reset();
 }
 
-TeamCommand TeamReceiver::packet_pb_msg_to_team_command(fira_message::sim_to_ref::Packet* p_packet) {
-    TeamCommand team_cmd;
-
+void TeamReceiver::packet_pb_msg_to_team_command(fira_message::sim_to_ref::Packet* p_packet, TeamCommand* p_team_cmd) {
     for (const auto& robot_cmd : p_packet->cmd().robot_commands()) {
         if (robot_cmd.yellowteam() == this->is_yellow) {
             int robot_id = robot_cmd.id();
@@ -88,15 +86,13 @@ TeamCommand TeamReceiver::packet_pb_msg_to_team_command(fira_message::sim_to_ref
                 continue;
             }
 
-            team_cmd.robot_command[robot_id].left_speed = robot_cmd.wheel_left();
-            team_cmd.robot_command[robot_id].right_speed = robot_cmd.wheel_right();
+            p_team_cmd->robot_command[robot_id].left_speed = robot_cmd.wheel_left();
+            p_team_cmd->robot_command[robot_id].right_speed = robot_cmd.wheel_right();
         } else {
             ROS_WARN("Error: Team %s receiver and command colors don't match!",
                      this->is_yellow ? "yellow" : "blue");
         }
     }
-
-    return team_cmd;
 }
 }  // namespace proto
 }  // namespace travesim

--- a/src/lib/protobuf/team_receiver.cpp
+++ b/src/lib/protobuf/team_receiver.cpp
@@ -1,0 +1,102 @@
+/**
+ * @file team_receiver.cpp
+ *
+ * @author Lucas Haug <lucas.haug@thunderatz.org>
+ *
+ * @brief Team control data receiver with UDP and protobuf
+ *
+ * @date 04/2021
+ *
+ * @copyright MIT License - Copyright (c) 2021 ThundeRatz
+ */
+
+#include <ros/console.h>
+
+#include "travesim_adapters/protobuf/team_receiver.hpp"
+
+/*****************************************
+ * Private Constants
+ *****************************************/
+
+#define BUFFER_SIZE 1024U
+
+/*****************************************
+ * Public Methods Bodies Definitions
+ *****************************************/
+
+namespace travesim {
+namespace proto {
+TeamReceiver::TeamReceiver(const std::string receiver_address, const short receiver_port, bool is_yellow) {
+    this->unicast_receiver =
+        new udp::UnicastReceiver(receiver_address, receiver_port);
+    this->unicast_receiver->force_specific_source(true);
+
+    this->is_yellow = is_yellow;
+}
+
+TeamReceiver::~TeamReceiver() {
+    delete this->unicast_receiver;
+}
+
+bool TeamReceiver::receive(TeamCommand* p_team_cmd) {
+    char buffer[BUFFER_SIZE];
+
+    if (this->unicast_receiver->receive(buffer, BUFFER_SIZE) > 0) {
+        fira_message::sim_to_ref::Packet packet_data;
+        packet_data.ParseFromArray(buffer, BUFFER_SIZE);
+
+        if (packet_data.has_cmd()) {
+            *p_team_cmd = this->packet_pb_msg_to_team_command(&packet_data);
+
+            last_team_cmd = *p_team_cmd;
+
+            return true;
+        } else {
+            *p_team_cmd = last_team_cmd;
+        }
+    } else {
+        *p_team_cmd = last_team_cmd;
+    }
+
+    return false;
+}
+
+void TeamReceiver::set_receiver_endpoint(const std::string receiver_address, const short receiver_port) {
+    this->unicast_receiver->set_receiver_endpoint(receiver_address,
+                                                  receiver_port);
+    this->unicast_receiver->reset();
+}
+
+void TeamReceiver::reset(void) {
+    this->unicast_receiver->reset();
+}
+
+TeamCommand TeamReceiver::packet_pb_msg_to_team_command(fira_message::sim_to_ref::Packet* p_packet) {
+    TeamCommand team_cmd;
+
+    for (const auto& robot_cmd : p_packet->cmd().robot_commands()) {
+        if (robot_cmd.yellowteam() == this->is_yellow) {
+            int robot_id = robot_cmd.id();
+
+            if ((robot_id < 0) || (robot_id >= NUM_OF_ROBOTS_PER_TEAM)) {
+                ROS_WARN_STREAM("Error: Invalid robot id in team receiver!");
+                continue;
+            }
+
+            if (isnanf(robot_cmd.wheel_left()) || isnanf(robot_cmd.wheel_right())) {
+                ROS_WARN_STREAM("Error: Invalid robot speed in team receiver!");
+                continue;
+            }
+
+            team_cmd.robot_command[robot_id].left_speed = robot_cmd.wheel_left();
+            team_cmd.robot_command[robot_id].right_speed = robot_cmd.wheel_right();
+        } else {
+            ROS_WARN("Error: Team %s receiver and command colors don't match!",
+                     this->is_yellow ? "yellow" : "blue");
+        }
+    }
+
+    return team_cmd;
+}
+}  // namespace proto
+}  // namespace travesim

--- a/src/lib/protobuf/team_receiver.cpp
+++ b/src/lib/protobuf/team_receiver.cpp
@@ -41,7 +41,7 @@ TeamReceiver::~TeamReceiver() {
 bool TeamReceiver::receive(TeamCommand* p_team_cmd) {
     char buffer[BUFFER_SIZE];
 
-    if (this->unicast_receiver->receive(buffer, BUFFER_SIZE) > 0) {
+    if (this->unicast_receiver->receive_latest(buffer, BUFFER_SIZE) > 0) {
         fira_message::sim_to_ref::Packet packet_data;
         packet_data.ParseFromArray(buffer, BUFFER_SIZE);
 


### PR DESCRIPTION
Olarrr, venho aqui trazer o receptor de comandos dos time, a parte que recebe os comandos com protobuf/udp e retorna pro nosso código principal um TeamCommand atualizado. 

Pra testar se tava recebendo certinho eu usei os arquivos de teste do fira_thundervolt, um detalhe é que lá a gente tava testando a comunicação só, então mandávamos comandos pros dois times no mesmo endpoint, mas aqui é um receptor pra um time só, como dá pra ver no próprio nome da classe que adicionei (`TeamReceiver`), então pra testar com os scripts de teste de intregração de lá tem que comentar um dos transmissores.

Falando algumas coisas importantes que levei em conta pra fazer essas coisas. 

Primeiramente, como falei, o `TeamReceiver` é um receptor pra somente um time, a gente teria que criar um desses pra cada time com endpoints diferentes, isso pra gente fazer aquelas verificações de mais de um time tentando se comunicar com o mesmo receptor. Falando nisso, ativei aí também o `specific_source`, ou seja, se um transmissor já se comunicou com o `TeamReceiver`, se um outro transmissor com endpoint diferetne tentar se comunicar ele, caso a gente não dê `reset`, ele vai jogar uma exceção e o programa morre (se a gente não tratar a exceção né). Isso tudo pra garantir que só um time vai controlar um time.

Outra coisa aqui é o método de conversão das mensagens. Acabei deixando como método da classe por alguns motivos. Um primeiro ponto, que seria contornável, é que eu usei um atributo da classe dentro do método, o atributo que indica qual é a cor do, pois isso è necessário pra fazer a conversão. Além disso como podem ver, fiz o método receber um ponteiro pra um TeamCommand ao invés de simplesmente pegar uma mensagem do protobuf e transformar no TeamCommand, isso porque nem sempre a gente vai receber os comandos pros três robôs, então eu coloquei pra só atualizar os comandos que recebi, deixando os que não recebei inalterados. Então essa lógica de só atualizar os que recebi acho que faz muito mais sentido sendo essa função um método da classe, até porque teria como fazer essa mesma lógica dentro da função de receive, mas de um jeito bem mais rolê. Por fim, como quero mudar os `.proto` depois, acho melhor essas coisas de protobuf ficarem só dentro das classes de protobuf, porque senão ia começar a espalhar protobuf por vários arquivos e na hora de refletir as mudanças dos `.proto` aqui nos adapters seria bem mais rolê.

Por último queria dizer que mudei umas coisinhas de lugares no CMakeLists só pra deixar coisas em comum juntas.