### PR TITLE
🚑🚑🚑🚑🚑 Fix quaternion conversion

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           check_name: tests report
           files: test_results/**/*.xml
-          comment_on_pr: false
+          comment_mode: off

--- a/src/lib/data/converter/ros_side.cpp
+++ b/src/lib/data/converter/ros_side.cpp
@@ -10,7 +10,7 @@
 
 #include "travesim_adapters/data/converter/ros_side.hpp"
 
-#define quaternion_to_theta(q0, q1, q2, q3) atan2(2*(q0*q1+q2*q3), 1 - 2*(q1*q1 + q2*q2))
+#define quaternion_to_theta(qw, qx, qy, qz) atan2(2 * (qw * qz + qx * qy), 1 - 2 * (qy * qy + qz * qz))
 
 typedef std::unordered_map<std::string, travesim::EntityState*> lookup_table_t;
 

--- a/src/lib/data/converter/ros_side.cpp
+++ b/src/lib/data/converter/ros_side.cpp
@@ -86,9 +86,9 @@ gazebo_msgs::ModelState EntityState_to_ModelState(EntityState* entity_state, dou
     retval.pose.position = Vector2D_to_Point(&entity_state->position, z);
 
     retval.pose.orientation.w = cos(entity_state->angular_position/2);
-    retval.pose.orientation.x = sin(entity_state->angular_position/2);
+    retval.pose.orientation.x = 0;
     retval.pose.orientation.y = 0;
-    retval.pose.orientation.z = 0;
+    retval.pose.orientation.z = sin(entity_state->angular_position/2);
 
     retval.twist.linear = Vector2D_to_Vector3(&entity_state->velocity);
 


### PR DESCRIPTION
Plot twist, tinha uma coisinha que tava causando o problema de resposta dos robôs, que era a conversão de quaterninon pra theta, aí esse problema pequena ia em cascata e afetava muita coisa. Dá pra ver a função de conversão certa [aqui](https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Source_code_2).