### PR TITLE
🥅 Catch address already in use error

### DIFF
--- a/include/travesim_adapters/udp/receiver.hpp
+++ b/include/travesim_adapters/udp/receiver.hpp
@@ -104,6 +104,9 @@ class Receiver {
          *  // Set blocking mode
          *  this->socket->non_blocking(true);
          * @endcode
+         *
+         * @note When opening a socket, if the socket is already bound to an endpoint,
+         *       a boost::wrapexcept<boost::system::system_error> exception is thrown.
          */
         virtual void open_socket() = 0;
 

--- a/src/lib/protobuf/replacer_receiver.cpp
+++ b/src/lib/protobuf/replacer_receiver.cpp
@@ -78,7 +78,11 @@ void ReplacerReceiver::force_specific_source(bool force_specific_source) {
 }
 
 void ReplacerReceiver::reset(void) {
-    this->unicast_receiver->reset();
+    try {
+        this->unicast_receiver->reset();
+    } catch (std::exception& e) {
+        ROS_ERROR_STREAM("Replacer receiver: " << e.what());
+    }
 }
 
 EntityState ReplacerReceiver::ball_rplcmt_pb_to_entity_state(

--- a/src/lib/protobuf/team_receiver.cpp
+++ b/src/lib/protobuf/team_receiver.cpp
@@ -80,7 +80,11 @@ void TeamReceiver::force_specific_source(bool force_specific_source) {
 }
 
 void TeamReceiver::reset(void) {
-    this->unicast_receiver->reset();
+    try {
+        this->unicast_receiver->reset();
+    } catch (std::exception& e) {
+        ROS_ERROR_STREAM((this->is_yellow ? "Yellow" : "Blue") << " team receiver: " << e.what());
+    }
 }
 
 void TeamReceiver::packet_pb_msg_to_team_command(fira_message::sim_to_ref::Packet* p_packet, TeamCommand* p_team_cmd) {


### PR DESCRIPTION
Pra resolver a issue #27 coloquei um try catch no método de `reset`, que é quando os endereços são redefinidos. Quando os objetos são criados não precisaria disso, porque eles usam os endereços padrões que estão certos e se não der pra criar o objeto dos receptores, aí tem que morrer mesmo o node haususaushushasu.